### PR TITLE
Temporarily remove async calls on cleanup playbook

### DIFF
--- a/tests/ci_environments/aws_ubuntu/ansible/cleanup.yml
+++ b/tests/ci_environments/aws_ubuntu/ansible/cleanup.yml
@@ -15,7 +15,7 @@
         name: "{{ connec.auto_scaling_group.jobs.name }}"
         region: "{{ aws_region }}"
         state: absent
-      async: 300
+      #async: 300
       poll: 0
 
     - name: Destroy Connec! Launch Configuration Background Jobs
@@ -29,7 +29,7 @@
         name: "{{ connec.auto_scaling_group.api.name }}"
         region: "{{ aws_region }}"
         state: absent
-      async: 300
+      #async: 300
       poll: 0
 
     - name: Destroy Connec! Launch Configuration API
@@ -50,7 +50,7 @@
         region: "{{ aws_region }}"
         state: absent
       ignore_errors: True
-      async: 300
+      #async: 300
       poll: 0
 
     #=======================================
@@ -61,7 +61,7 @@
         name: "{{ impac.auto_scaling_group.name }}"
         region: "{{ aws_region }}"
         state: absent
-      async: 300
+      #async: 300
       poll: 0
 
     - name: Destroy Impac! Launch Configuration
@@ -82,7 +82,7 @@
         region: "{{ aws_region }}"
         state: absent
       ignore_errors: True
-      async: 300
+      #async: 300
       poll: 0
 
     #=======================================
@@ -93,7 +93,7 @@
         name: "{{ mnohub.auto_scaling_group.name }}"
         region: "{{ aws_region }}"
         state: absent
-      async: 300
+      #async: 300
       poll: 0
 
     - name: Destroy MnoHub Launch Configuration
@@ -114,7 +114,7 @@
         region: "{{ aws_region }}"
         state: absent
       ignore_errors: True
-      async: 300
+      #async: 300
       poll: 0
 
     #=======================================
@@ -154,7 +154,7 @@
       rds:
         command: delete
         instance_name: "{{ rds.name }}"
-      async: 600
+      #async: 600
       poll: 0
 
     #=======================================


### PR DESCRIPTION
Async cleanup will need to be reworked so that it doesn't try to delete the LCs before the autoscale groups. I'm disabling the async calls for the time being.
