### PR TITLE
remove a cache in nginx for calls from devplatform

### DIFF
--- a/ansible/roles/dev-platform/templates/etc-nginx-dev-platform
+++ b/ansible/roles/dev-platform/templates/etc-nginx-dev-platform
@@ -38,7 +38,7 @@ server {
   try_files $uri $uri/ /index.html;
 
   location @dev_platform {
-    expires      1h;
+    expires      -1;
     proxy_cache  off;
     proxy_pass http://dev_platform;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This `expires` is the one creating the header `Cache-Control: max-age=3600`.
@BrunoChauvet Can you review and merge. Thanks.
