### PR TITLE
add ENV['XROV2_PARALLEL_THREADS']

### DIFF
--- a/ansible/roles/connec/defaults/main.yml
+++ b/ansible/roles/connec/defaults/main.yml
@@ -26,3 +26,4 @@ connec_config:
       xms: "{{ (0.70 * ansible_memtotal_mb)|int }}m"
       xmx: "{{ (0.70 * ansible_memtotal_mb)|int }}m" # Allocate 75% of server memory for Sidekiq
       max_perm_size: 512m
+  xrov2_parallel_threads: 2

--- a/ansible/roles/connec/templates/application.yml
+++ b/ansible/roles/connec/templates/application.yml
@@ -19,3 +19,5 @@ SYNC_JOB_BATCHES: {{ connec_config.sidekiq.sync_job_batches }}
 FORCE_SSL: {{ connec_config.force_ssl }}
 
 OPENEXCHANGERATES_APP_ID: {{ mnohub_config.secrets.open_exchange_rate_id }}
+
+XROV2_PARALLEL_THREADS: {{ connec_config.xrov2_parallel_threads }}


### PR DESCRIPTION
Default is set at 2 as per the default value specified in Connec! code.
see https://github.com/maestrano/mno-deploy-maestrano/pull/145