### PR TITLE
Deprecate Xero entrust certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ ssh_users:
 To support Xero API Partner access, certificate files must be added to `ansible/files/xero_certs/RAILS_ENVIRONMENT/`
 The list of file to include are:
 - privatekey.pem
-- entrust-cert.pem
-- entrust-private-nopass.pem
 
 ### Redis configuration
 #### Custom parameter group

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1270,10 +1270,9 @@ connec_config:
     xero:
       key:
       secret:
-      endpoint: https://api-partner.network.xero.com/api.xro/2.0
+      endpoint: https://api.xero.com/api.xro/2.0
+      site: https://api.xero.com
       private_key: "vendor/xero-certs/{{ rails_environment }}/privatekey.pem"
-      ssl_client_cert: "vendor/xero-certs/{{ rails_environment }}/entrust-cert.pem"
-      ssl_client_key: "vendor/xero-certs/{{ rails_environment }}/entrust-private-nopass.pem"
       signature_method: RSA-SHA1
       user_agent: "{{ application_name }} {{ rails_environment }}"
     quickbooks:

--- a/ansible/roles/connec/tasks/deploy.yml
+++ b/ansible/roles/connec/tasks/deploy.yml
@@ -106,6 +106,7 @@
     - privatekey.pem
     - entrust-cert.pem
     - entrust-private-nopass.pem
+  ignore_errors: True
   tags: [xero]
 
 - name: Connec | Symbolic link to log directory

--- a/ansible/roles/connec/tasks/setup.yml
+++ b/ansible/roles/connec/tasks/setup.yml
@@ -6,6 +6,8 @@
     - mongodb-clients
   when: ansible_os_family == "Debian"
 
+# This is to copy Xero hosts trusted certificates on Debian
+# Xero Certificate Authority may not be accepted an all distributions
 - name: Connec | Copy SSL Certification Authorities for Xero
   copy:
     src: "{{ item }}"
@@ -22,6 +24,7 @@
 - name: Connec | Install SSL Certification Authorities
   shell: 'update-ca-certificates'
   when: ansible_os_family == "Debian"
+  tags: [xero]
 
 - name: Connec | Nginx default site deactivation
   file: path=/etc/nginx/sites-enabled/default.conf state=absent

--- a/ansible/roles/maestrano/tasks/deploy.yml
+++ b/ansible/roles/maestrano/tasks/deploy.yml
@@ -114,6 +114,7 @@
     - privatekey.pem
     - entrust-cert.pem
     - entrust-private-nopass.pem
+  ignore_errors: True
   tags: [xero]
 
 - name: MNO Hub | Disable Sunspot::Solr

--- a/ansible/roles/mnohub/tasks/deploy.yml
+++ b/ansible/roles/mnohub/tasks/deploy.yml
@@ -107,6 +107,7 @@
     - privatekey.pem
     - entrust-cert.pem
     - entrust-private-nopass.pem
+  ignore_errors: True
   tags: [xero]
 
 - name: MnoHub | Set directory permissions

--- a/ansible/vars/example_secrets.yml
+++ b/ansible/vars/example_secrets.yml
@@ -112,11 +112,9 @@ connec_config:
     xero:
       key: changeme # Use your Xero OAuth keys
       secret: changeme # Use your Xero OAuth keys
-      endpoint: https://api-partner.network.xero.com/api.xro/2.0
-      site: https://api-partner.network.xero.com
+      endpoint: https://api.xero.com/api.xro/2.0
+      site: https://api.xero.com
       private_key: vendor/xero-certs/uat/privatekey.pem
-      ssl_client_cert: vendor/xero-certs/uat/entrust-cert.pem
-      ssl_client_key: vendor/xero-certs/uat/entrust-private-nopass.pem
       signature_method: RSA-SHA1
       user_agent: Maestrano UAT
     quickbooks:


### PR DESCRIPTION
See: https://developer.xero.com/documentation/auth-and-limits/entrust-certificate-deprecation
- Update any reference from `https://api-partner.network.xero.com` to `https://api.xero.com`
- Remove Entrust SSL certificates when creating an instance of http client object