### PR TITLE
Install missing dependencies required for pycrypto

### DIFF
--- a/ansible/roles/ec2-infra/templates/user_data.sh
+++ b/ansible/roles/ec2-infra/templates/user_data.sh
@@ -36,14 +36,14 @@ export no_proxy="localhost,169.254.169.254"
 #====================================================
 # Ubuntu: Install Dependencies
 if [ "$(which apt-get > /dev/null 2>&1)$?" == "0" ]; then
-  apt-get -y update && apt-get install -y python-pip libffi-dev libssl-dev
+  apt-get -y update && apt-get install -y python-pip libffi-dev libssl-dev python-dev
 fi
 
 # RHEL: Install depdendencies
 if [ "$(which yum > /dev/null 2>&1)$?" == "0" ]; then
   # Enable EPEL
   rpm -iUvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-  yum -y update && yum install -y python-pip
+  yum -y update && yum install -y python-pip libffi-devel python-devel openssl-devel
 fi
 
 # Upgrade setup tools to avoid old versions on certain distributions

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,7 +30,7 @@ do_install() {
   apt-get -y update
   apt-get -y upgrade
   apt-get -y install build-essential
-  apt-get -q -y --no-install-recommends install unattended-upgrades git python-yaml libyaml-dev python-jinja2 python-httplib2 python-keyczar python-dev python-pip
+  apt-get -q -y --no-install-recommends install unattended-upgrades git python-yaml libyaml-dev python-jinja2 python-httplib2 python-keyczar python-dev libffi-dev libssl-dev python-pip
   pip install -Iv ansible==2.0.2.0
   pip install boto pycrypto
 


### PR DESCRIPTION
Starting a new instance, the setup was failing with
```
Command python setup.py egg_info failed with error code 1 in /tmp/pip_build_root/pynacl
```

Installing the packages `libffi-dev libssl-dev` fixed the issue