### PR TITLE
Add option to skip ASG, LC and ELB of components

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -525,6 +525,7 @@ maestrano:
 mnohub:
   skip: true # new mnohub is not yet part of the default implementation
   redis:
+    skip: false
     name: "{{ environment_name }}-mnohub-redis"
     node_type: cache.t2.micro
     num_nodes: 1
@@ -533,6 +534,7 @@ mnohub:
     cache_engine_version: 3.2.4
     cache_parameter_group: "default.redis3.2"
   elastic_load_balancer:
+    skip: false
     name: "{{ vpc_short_name }}-mnohub-elb"
     connection_draining_timeout: 60
     zones: "{{ aws_availability_zones }}"
@@ -562,6 +564,7 @@ mnohub:
     ttl: 60
     overwrite: yes
   launch_configuration:
+    skip: false
     name: "{{ vpc_short_name }}-mnohub-lc"
     image_id: "{{ default_base_ami }}"
     key_name: "{{ keypair }}"
@@ -571,6 +574,7 @@ mnohub:
       - "{{ created_security_groups.results[4].group_id }}" # RDS security group
       - "{{ created_security_groups.results[7].group_id }}" # TorqueBox cluster security group
   auto_scaling_group:
+    skip: false
     name: "{{ vpc_short_name }}-mnohub-asg"
     availability_zones: "{{ aws_availability_zones }}"
     vpc_zone_identifier:
@@ -589,6 +593,7 @@ mnohub:
 nex:
   skip: true
   redis:
+    skip: false
     name: "{{ environment_name }}-nex-redis"
     node_type: cache.t2.micro
     num_nodes: 1
@@ -597,6 +602,7 @@ nex:
     cache_engine_version: 3.2.4
     cache_parameter_group: "default.redis3.2"
   elastic_load_balancer:
+    skip: false
     name: "{{ vpc_short_name }}-nex-elb"
     connection_draining_timeout: 60
     zones: "{{ aws_availability_zones }}"
@@ -626,6 +632,7 @@ nex:
     ttl: 60
     overwrite: yes
   launch_configuration:
+    skip: false
     name: "{{ vpc_short_name }}-nex-lc"
     image_id: "{{ default_base_ami }}"
     key_name: "{{ keypair }}"
@@ -635,6 +642,7 @@ nex:
       - "{{ created_security_groups.results[4].group_id }}" # RDS security group
       - "{{ created_security_groups.results[7].group_id }}" # TorqueBox cluster security group
   auto_scaling_group:
+    skip: false
     name: "{{ vpc_short_name }}-nex-asg"
     availability_zones: "{{ aws_availability_zones }}"
     vpc_zone_identifier:
@@ -653,6 +661,7 @@ nex:
 connec:
   skip: false
   redis:
+    skip: false
     name: connec-redis
     node_type: cache.t2.micro
     num_nodes: 1
@@ -661,6 +670,7 @@ connec:
     cache_engine_version: 3.2.4
     cache_parameter_group: "default.redis3.2"
   elastic_load_balancer:
+    skip: false
     name: "{{ vpc_short_name }}-connec-elb"
     connection_draining_timeout: 600
     zones: "{{ aws_availability_zones }}"
@@ -690,6 +700,7 @@ connec:
     ttl: 60
     overwrite: yes
   launch_configuration:
+    skip: false
     api:
       name: "{{ vpc_short_name }}-connec-api-lc"
       image_id: "{{ default_base_ami }}"
@@ -709,6 +720,7 @@ connec:
         - "{{ created_security_groups.results[4].group_id }}" # RDS security group
         - "{{ created_security_groups.results[5].group_id }}" # MongoDB security group
   auto_scaling_group:
+    skip: false
     api:
       name: "{{ vpc_short_name }}-connec-api-asg"
       availability_zones: "{{ aws_availability_zones }}"
@@ -742,6 +754,7 @@ connec:
 impac:
   skip: false
   redis:
+    skip: false
     name: impac-redis
     node_type: cache.t2.micro
     num_nodes: 1
@@ -750,6 +763,7 @@ impac:
     cache_engine_version: 3.2.4
     cache_parameter_group: "default.redis3.2"
   elastic_load_balancer:
+    skip: false
     name: "{{ vpc_short_name }}-impac-elb"
     connection_draining_timeout: 600
     zones: "{{ aws_availability_zones }}"
@@ -779,6 +793,7 @@ impac:
     ttl: 60
     overwrite: yes
   launch_configuration:
+    skip: false
     name: "{{ vpc_short_name }}-impac-lc"
     image_id: "{{ default_base_ami }}"
     key_name: "{{ keypair }}"
@@ -786,6 +801,7 @@ impac:
     security_groups:
       - "{{ created_security_groups.results[3].group_id }}" # Public tier security group
   auto_scaling_group:
+    skip: false
     name: "{{ vpc_short_name }}-impac-asg"
     availability_zones: "{{ aws_availability_zones }}"
     vpc_zone_identifier:

--- a/ansible/roles/ec2-infra/tasks/connec.yml
+++ b/ansible/roles/ec2-infra/tasks/connec.yml
@@ -17,6 +17,7 @@
     security_group_ids: "{{ redis_group.vpc_security_groups }}"
     region: "{{ aws_region }}"
     wait: yes
+  when: not connec.redis.skip
   register: created_connec_redis
 
 - name: Add Redis Store DNS record
@@ -30,6 +31,7 @@
     alias: False
     ttl: 60
     private_zone: "{{ route53.zone.private_zone }}"
+  when: not connec.redis.skip
 
 - name: Create Connec! ELB
   ec2_elb_lb:
@@ -45,6 +47,7 @@
     security_group_ids: "{{ connec.elastic_load_balancer.security_group_ids }}"
     listeners: "{{ connec.elastic_load_balancer.listeners }}"
     health_check: "{{ connec.elastic_load_balancer.health_check }}"
+  when: not connec.elastic_load_balancer.skip
   register: connec_elastic_load_balancer
 
 - name: Add DNS record for ELB
@@ -59,6 +62,7 @@
     private_zone: "{{ route53.zone.private_zone }}"
     alias_hosted_zone_id: "{{ connec.elastic_load_balancer.alias_hosted_zone_id }}"
     overwrite: "{{ connec.dns_record.overwrite }}"
+  when: not connec.elastic_load_balancer.skip
 
 - set_fact: maestrano_component="connec-api-server-local"
 
@@ -78,7 +82,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
-  when: connec.launch_configuration.api.spot_price is undefined or connec.launch_configuration.api.spot_price is none
+  when: not connec.launch_configuration.skip and (connec.launch_configuration.api.spot_price is undefined or connec.launch_configuration.api.spot_price is none)
 
 - name: Create Connec! Launch Configuration API (spot instances)
   ec2_lc:
@@ -97,7 +101,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
-  when: connec.launch_configuration.api.spot_price is defined and connec.launch_configuration.api.spot_price is not none
+  when: not connec.launch_configuration.skip and (connec.launch_configuration.api.spot_price is defined and connec.launch_configuration.api.spot_price is not none)
 
 - name: Create Connec! Auto Scaling Group API
   ec2_asg:
@@ -113,6 +117,7 @@
     availability_zones: "{{ connec.auto_scaling_group.api.availability_zones }}"
     load_balancers: "{{ connec.elastic_load_balancer.name }}"
     tags: "{{ connec.auto_scaling_group.api.tags }}"
+  when: not connec.auto_scaling_group.skip
   register: connec_auto_scaling_group
 
 - set_fact: maestrano_component="connec-jobs-server-local"
@@ -133,7 +138,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
-  when: connec.launch_configuration.jobs.spot_price is undefined or connec.launch_configuration.jobs.spot_price is none
+  when: not connec.launch_configuration.skip and (connec.launch_configuration.jobs.spot_price is undefined or connec.launch_configuration.jobs.spot_price is none)
 
 - name: Create Connec! Launch Configuration Background Jobs (spot instances)
   ec2_lc:
@@ -152,7 +157,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
-  when: connec.launch_configuration.jobs.spot_price is defined and connec.launch_configuration.jobs.spot_price is not none
+  when: not connec.launch_configuration.skip and (connec.launch_configuration.jobs.spot_price is defined and connec.launch_configuration.jobs.spot_price is not none)
 
 - name: Create Connec! Auto Scaling Group Background Jobs
   ec2_asg:
@@ -167,4 +172,5 @@
     vpc_zone_identifier: "{{ connec.auto_scaling_group.jobs.vpc_zone_identifier }}"
     availability_zones: "{{ connec.auto_scaling_group.jobs.availability_zones }}"
     tags: "{{ connec.auto_scaling_group.jobs.tags }}"
+  when: not connec.auto_scaling_group.skip
   register: connec_auto_scaling_group

--- a/ansible/roles/ec2-infra/tasks/connec.yml
+++ b/ansible/roles/ec2-infra/tasks/connec.yml
@@ -23,6 +23,7 @@
   route53:
     command: create
     zone: "{{ (route53.zone.name|string) }}"
+    alias_hosted_zone_id: "{{ route53.zone.id }}"
     record: "{{ connec.redis.endpoint }}"
     type: CNAME
     value: "{{ created_connec_redis.elasticache.data.CacheNodes[0].Endpoint.Address }}"

--- a/ansible/roles/ec2-infra/tasks/dev-platform.yml
+++ b/ansible/roles/ec2-infra/tasks/dev-platform.yml
@@ -24,6 +24,7 @@
   route53:
     command: create
     zone: "{{ (route53.zone.name|string) }}"
+    alias_hosted_zone_id: "{{ route53.zone.id }}"
     record: "{{ dev_platform.redis.endpoint }}"
     type: CNAME
     value: "{{ created_dev_platform_redis.elasticache.data.CacheNodes[0].Endpoint.Address }}"

--- a/ansible/roles/ec2-infra/tasks/impac.yml
+++ b/ansible/roles/ec2-infra/tasks/impac.yml
@@ -24,6 +24,7 @@
   route53:
     command: create
     zone: "{{ (route53.zone.name|string) }}"
+    alias_hosted_zone_id: "{{ route53.zone.id }}"
     record: "{{ impac.redis.endpoint }}"
     type: CNAME
     value: "{{ created_impac_redis.elasticache.data.CacheNodes[0].Endpoint.Address }}"

--- a/ansible/roles/ec2-infra/tasks/impac.yml
+++ b/ansible/roles/ec2-infra/tasks/impac.yml
@@ -18,6 +18,7 @@
     security_group_ids: "{{ redis_group.vpc_security_groups }}"
     region: "{{ aws_region }}"
     wait: yes
+  when: not impac.redis.skip
   register: created_impac_redis
 
 - name: Add Redis Store DNS record
@@ -31,6 +32,7 @@
     alias: False
     ttl: 60
     private_zone: "{{ route53.zone.private_zone }}"
+  when: not impac.redis.skip
 
 - name: Create Impac! ELB
   ec2_elb_lb:
@@ -46,6 +48,7 @@
     security_group_ids: "{{ impac.elastic_load_balancer.security_group_ids }}"
     listeners: "{{ impac.elastic_load_balancer.listeners }}"
     health_check: "{{ impac.elastic_load_balancer.health_check }}"
+  when: not impac.elastic_load_balancer.skip
   register: impac_elastic_load_balancer
 
 - name: Add DNS record for ELB
@@ -60,6 +63,7 @@
     private_zone: "{{ route53.zone.private_zone }}"
     alias_hosted_zone_id: "{{ impac.elastic_load_balancer.alias_hosted_zone_id }}"
     overwrite: "{{ impac.dns_record.overwrite }}"
+  when: not impac.elastic_load_balancer.skip
 
 - name: Create Impac! Launch Configuration
   ec2_lc:
@@ -77,7 +81,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
-  when: impac.launch_configuration.spot_price is undefined or impac.launch_configuration.spot_price is none
+  when: not impac.launch_configuration.skip and (impac.launch_configuration.spot_price is undefined or impac.launch_configuration.spot_price is none)
 
 - name: Create Impac! Launch Configuration (spot instances)
   ec2_lc:
@@ -96,7 +100,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
-  when: impac.launch_configuration.spot_price is defined and impac.launch_configuration.spot_price is not none
+  when: not impac.launch_configuration.skip and (impac.launch_configuration.spot_price is defined and impac.launch_configuration.spot_price is not none)
 
 - name: Create Impac! Auto Scaling Group
   ec2_asg:
@@ -112,4 +116,5 @@
     availability_zones: "{{ impac.auto_scaling_group.availability_zones }}"
     load_balancers: "{{ impac.elastic_load_balancer.name }}"
     tags: "{{ impac.auto_scaling_group.tags }}"
+  when: not impac.auto_scaling_group.skip
   register: impac_auto_scaling_group

--- a/ansible/roles/ec2-infra/tasks/mnohub.yml
+++ b/ansible/roles/ec2-infra/tasks/mnohub.yml
@@ -24,6 +24,7 @@
   route53:
     command: create
     zone: "{{ (route53.zone.name|string) }}"
+    alias_hosted_zone_id: "{{ route53.zone.id }}"
     record: "{{ mnohub.redis.endpoint }}"
     type: CNAME
     value: "{{ created_mnohub_redis.elasticache.data.CacheNodes[0].Endpoint.Address }}"

--- a/ansible/roles/ec2-infra/tasks/mnohub.yml
+++ b/ansible/roles/ec2-infra/tasks/mnohub.yml
@@ -18,6 +18,7 @@
     security_group_ids: "{{ redis_group.vpc_security_groups }}"
     region: "{{ aws_region }}"
     wait: yes
+  when: not mnohub.redis.skip
   register: created_mnohub_redis
 
 - name: MnoHub | Add Redis Store DNS record
@@ -31,6 +32,7 @@
     alias: False
     ttl: 60
     private_zone: "{{ route53.zone.private_zone }}"
+  when: not mnohub.redis.skip
 
 - name: Create MnoHub ELB
   ec2_elb_lb:
@@ -46,6 +48,7 @@
     security_group_ids: "{{ mnohub.elastic_load_balancer.security_group_ids }}"
     listeners: "{{ mnohub.elastic_load_balancer.listeners }}"
     health_check: "{{ mnohub.elastic_load_balancer.health_check }}"
+  when: not mnohub.elastic_load_balancer.skip
   register: mnohub_elastic_load_balancer
 
 - name: Add DNS record for MnoHub ELB
@@ -60,6 +63,7 @@
     private_zone: "{{ route53.zone.private_zone }}"
     alias_hosted_zone_id: "{{ mnohub.elastic_load_balancer.alias_hosted_zone_id }}"
     overwrite: "{{ mnohub.dns_record.overwrite }}"
+  when: not mnohub.elastic_load_balancer.skip
 
 - name: Create MnoHub Launch Configuration
   ec2_lc:
@@ -77,7 +81,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
-  when: mnohub.launch_configuration.spot_price is undefined or mnohub.launch_configuration.spot_price is none
+  when: not mnohub.launch_configuration.skip and (mnohub.launch_configuration.spot_price is undefined or mnohub.launch_configuration.spot_price is none)
 
 - name: Create MnoHub Launch Configuration (spot instances)
   ec2_lc:
@@ -96,7 +100,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
-  when: mnohub.launch_configuration.spot_price is defined and mnohub.launch_configuration.spot_price is not none
+  when: not mnohub.launch_configuration.skip and (mnohub.launch_configuration.spot_price is defined and mnohub.launch_configuration.spot_price is not none)
 
 - name: Create MnoHub Auto Scaling Group
   ec2_asg:
@@ -112,4 +116,5 @@
     availability_zones: "{{ mnohub.auto_scaling_group.availability_zones }}"
     load_balancers: "{{ mnohub.elastic_load_balancer.name }}"
     tags: "{{ mnohub.auto_scaling_group.tags }}"
+  when: not mnohub.auto_scaling_group.skip
   register: maestrano_auto_scaling_group

--- a/ansible/roles/ec2-infra/tasks/nex.yml
+++ b/ansible/roles/ec2-infra/tasks/nex.yml
@@ -18,6 +18,7 @@
     security_group_ids: "{{ redis_group.vpc_security_groups }}"
     region: "{{ aws_region }}"
     wait: yes
+  when: not nex.redis.skip
   register: created_nex_redis
 
 - name: Nex! | Add Redis Store DNS record
@@ -31,6 +32,7 @@
     alias: False
     ttl: 60
     private_zone: "{{ route53.zone.private_zone }}"
+  when: not nex.redis.skip
 
 - name: Nex! | Create Nex ELB
   ec2_elb_lb:
@@ -45,6 +47,7 @@
     subnets: "{{ nex.elastic_load_balancer.subnets }}"
     security_group_ids: "{{ nex.elastic_load_balancer.security_group_ids }}"
     listeners: "{{ nex.elastic_load_balancer.listeners }}"
+  when: not nex.elastic_load_balancer.skip
   register: nex_elastic_load_balancer
 
 - name: Add DNS record for ELB
@@ -76,6 +79,7 @@
         volume_size: 50
         device_type: gp2 # SSD
         delete_on_termination: true
+  when: not nex.launch_configuration.skip
 
 - name: Create Nex! Auto Scaling Group
   ec2_asg:
@@ -91,4 +95,5 @@
     availability_zones: "{{ nex.auto_scaling_group.availability_zones }}"
     load_balancers: "{{ nex.elastic_load_balancer.name }}"
     tags: "{{ nex.auto_scaling_group.tags }}"
+  when: not nex.auto_scaling_group.skip
   register: nex_auto_scaling_group

--- a/ansible/roles/ec2-infra/tasks/nex.yml
+++ b/ansible/roles/ec2-infra/tasks/nex.yml
@@ -24,6 +24,7 @@
   route53:
     command: create
     zone: "{{ (route53.zone.name|string) }}"
+    alias_hosted_zone_id: "{{ route53.zone.id }}"
     record: "{{ nex.redis.endpoint }}"
     type: CNAME
     value: "{{ created_nex_redis.elasticache.data.CacheNodes[0].Endpoint.Address }}"

--- a/ansible/roles/ec2-infra/tasks/rds.yml
+++ b/ansible/roles/ec2-infra/tasks/rds.yml
@@ -35,6 +35,7 @@
   route53:
     command: create
     zone: "{{ (route53.zone.name|string) }}"
+    alias_hosted_zone_id: "{{ route53.zone.id }}"
     record: "{{ rds.endpoint }}"
     type: CNAME
     value: "{{ rds_maestrano.instance.endpoint }}"


### PR DESCRIPTION
- Add parameter `alias_hosted_zone_id` mandatory with Ansible 2.4
- Add option to skip Redis, ASG and LC for each component deployment